### PR TITLE
Introduce testcontainers for integration testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,11 +103,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
             <scope>runtime</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,18 @@
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>1.18.3</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -124,6 +136,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mariadb</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/net/anatolich/iris/demo/SettlementDemoTest.java
+++ b/src/test/java/net/anatolich/iris/demo/SettlementDemoTest.java
@@ -1,17 +1,17 @@
 package net.anatolich.iris.demo;
 
 import net.anatolich.iris.domain.settlement.AccountingAccount;
-import net.anatolich.iris.domain.settlement.SettlementCheck;
 import net.anatolich.iris.domain.settlement.BankAccount;
+import net.anatolich.iris.domain.settlement.SettlementCheck;
 import net.anatolich.iris.domain.settlement.SettlementService;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@Disabled("waiting for testcontainers")
+@ActiveProfiles(profiles = "it")
 class SettlementDemoTest {
 
     @Autowired

--- a/src/test/java/net/anatolich/iris/subscription/ManageSubscriptionsTest.java
+++ b/src/test/java/net/anatolich/iris/subscription/ManageSubscriptionsTest.java
@@ -1,16 +1,9 @@
 package net.anatolich.iris.subscription;
 
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.equalTo;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.math.BigDecimal;
 import net.anatolich.iris.subscription.infra.rest.SubscriptionDto;
 import net.anatolich.iris.subscription.infra.rest.SubscriptionDto.ServiceDto;
 import org.javamoney.moneta.Money;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,13 +12,21 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureJson
 @DisplayName("manage subscriptions")
-@Disabled("waiting for testcontainers")
+@ActiveProfiles(profiles = "it")
 class ManageSubscriptionsTest {
 
     @Autowired

--- a/src/test/resources/application-it.yml
+++ b/src/test/resources/application-it.yml
@@ -1,0 +1,3 @@
+spring:
+  datasource:
+    url: jdbc:tc:mariadb:10.8-focal://iris


### PR DESCRIPTION
Testcontainers replaces usage of H2 database in tests.
Test are now run against MariaDB - same database Iris uses in production.

With upgrade to Spring Boot 3 the testcontainers will also be used to run local dev environments.